### PR TITLE
fix send test run result by run-workers option

### DIFF
--- a/testit-adapter-codecept/src/bootstrap.ts
+++ b/testit-adapter-codecept/src/bootstrap.ts
@@ -30,7 +30,7 @@ module.exports = async function (options) {
     });
   });
 
-  event.dispatcher.on(event.all.after, async () => {
+  event.dispatcher.on(event.workers.after, async () => {
     await strategy.teardown();
   });
 };


### PR DESCRIPTION
Исправлено закрытие test run при запуске в run-workers режиме. При завершение любого воркера происходило закрытие test run и все запущенные тесты переходили в статус "пропущен". Результаты тех тестов, что не успели отправить результаты задваивались, один результат со статусом Пропущен, другой с актуальным